### PR TITLE
Fixed the dependency on the JCAMP-DX feature

### DIFF
--- a/openchrom/features/net.openchrom.thirdpartylibraries.jcampdx.feature/feature.xml
+++ b/openchrom/features/net.openchrom.thirdpartylibraries.jcampdx.feature/feature.xml
@@ -505,7 +505,7 @@ That&apos;s all there is to it!
    </url>
 
    <plugin
-         id="jcamp-dx"
+         id="net.openchrom.thirdpartylibraries.jcampdx"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Followup of https://github.com/OpenChrom/openchrom3rdpl/pull/16. The Eclipse IDE had that name cached.