### PR TITLE
Fix referencing a missing plugin

### DIFF
--- a/openchrom/cbi/net.openchrom.thirdpartylibraries.cbi/pom.xml
+++ b/openchrom/cbi/net.openchrom.thirdpartylibraries.cbi/pom.xml
@@ -313,7 +313,6 @@
     <module>../../plugins/net.openchrom.thirdpartylibraries.jackcess</module>
     <module>../../features/net.openchrom.thirdpartylibraries.jackcess.feature</module>
     <!-- JDBC meta bundle -->
-    <module>../../plugins/net.openchrom.thirdpartylibraries.jdbc</module>
     <module>../../features/net.openchrom.thirdpartylibraries.jdbc.feature</module>
     <!-- Apache Imaging -->
     <module>../../plugins/net.openchrom.thirdpartylibraries.imaging</module>


### PR DESCRIPTION
Followup of https://github.com/OpenChrom/openchrom3rdpl/pull/22