### PR TITLE
Add Apache Commons

### DIFF
--- a/openchrom/cbi/thirdpartylibraries.targetplatform/thirdpartylibraries.targetplatform.target
+++ b/openchrom/cbi/thirdpartylibraries.targetplatform/thirdpartylibraries.targetplatform.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="OpenChrom GitHub (Third Party Libraries)" sequenceNumber="9">
+<?pde version="3.8"?><target name="OpenChrom Third Party Libraries" sequenceNumber="9">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
@@ -7,7 +7,8 @@
 <repository location="https://download.eclipse.org/chemclipse/integration/develop/repository"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="osgi.enterprise" version="4.2.0.v201108120515"/>
+<unit id="osgi.enterprise" version="0.0.0"/>
+<unit id="org.apache.commons.lang" version="0.0.0"/>
 <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20191126223242/repository"/>
 </location>
 </locations>


### PR DESCRIPTION
which is still required here for JDHF5 but was dropped in https://github.com/eclipse/chemclipse/pull/1148.