### PR TITLE
Don't include all dependencies

### DIFF
--- a/openchrom/pom.xml
+++ b/openchrom/pom.xml
@@ -143,7 +143,7 @@
 					<artifactId>tycho-p2-repository-plugin</artifactId>
 					<version>${tycho.version}</version>
 					<configuration>
-						<includeAllDependencies>true</includeAllDependencies>
+						<includeAllDependencies>false</includeAllDependencies>
 						<skipArchive>true</skipArchive>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
as this adds redundant files from the target platform into the update site.